### PR TITLE
ピンの表示、保存状態におけるエラーの解消、プレビューの仕様変更

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,13 @@ function App() {
         <Route path="/login" element={<Login />} />
         <Route
           path="/imageUpload"
-          element={<ImageUploader onFilesChange={() => {}} />}
+          element={
+            <ImageUploader
+              onFilesChange={() => {}}
+              onResetPreview={() => {}}
+              shouldResetPreview={false}
+            />
+          }
         />
         <Route path="/page" element={<SnapMapPage />} />
       </Routes>

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -1,5 +1,5 @@
 //src/components/ImageUploader.tsx
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { ImageUploaderStyles as s } from "../styles/ImageUploaderStyles";
 import { useFilePreviews } from "../hooks/useFilePreviews";
 import type { PreviewItem } from "../hooks/useFilePreviews";
@@ -13,11 +13,30 @@ import {
 //propsの型をinterfaceで定義
 interface ImageUploaderProps {
   onFilesChange: (files: File[]) => void;
+  onResetPreview: () => void;
+  shouldResetPreview: boolean;
 }
 
-const ImageUploader: React.FC<ImageUploaderProps> = ({ onFilesChange }) => {
+const ImageUploader: React.FC<ImageUploaderProps> = ({
+  onFilesChange,
+  onResetPreview,
+  shouldResetPreview,
+}) => {
   const [files, setFiles] = useState<File[]>([]); //選択されたファイルを配列管理するState
   const previews: PreviewItem[] = useFilePreviews(files); //プレビュー用URLを管理するState
+
+  // shouldResetPreviewが変化した時にリセット実行
+  useEffect(() => {
+    if (shouldResetPreview) {
+      setFiles([]);
+      onFilesChange([]);
+      const input = document.getElementById("fileInput") as HTMLInputElement;
+      if (input) {
+        input.value = "";
+      }
+      onResetPreview();
+    }
+  }, [shouldResetPreview, onFilesChange, onResetPreview]);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const fileList = e.currentTarget.files;

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -20,6 +20,7 @@ interface MapViewProps {
   markers?: MarkerVM[];
   options?: google.maps.MapOptions;
   onMapClick?: (latLng: google.maps.LatLngLiteral) => void;
+  onMarkerClick?: (marker: MarkerVM) => void;
 }
 
 const MapView: React.FC<MapViewProps> = ({
@@ -27,6 +28,7 @@ const MapView: React.FC<MapViewProps> = ({
   markers = [],
   options = {},
   onMapClick,
+  onMarkerClick,
 }) => {
   //マーカーを定義
   const defaultLabel: google.maps.MarkerLabel = {
@@ -58,6 +60,7 @@ const MapView: React.FC<MapViewProps> = ({
           key={idx}
           position={m.position}
           label={m.label ? { text: m.label } : defaultLabel}
+          onClick={() => onMarkerClick?.(m)}
           onLoad={(marker) => {
             //現在位置と選択位置でピンを分ける。マップ読み込み後にscaledSizeが設定されるようにsetIconで定義。
             if (m.kind === "current") {

--- a/src/hooks/useRecords.ts
+++ b/src/hooks/useRecords.ts
@@ -28,13 +28,8 @@ export const useRecords = () => {
   //既存のレコードを削除
   const deleteRecord = (place: LatLng) => {
     setRecords((prev) =>
-      prev.map((r) =>
-        r.place.lat === place.lat && r.place.lng === place.lng
-          ? {
-              ...r,
-              photos: [],
-            }
-          : r
+      prev.filter(
+        (r) => !(r.place.lat === place.lat && r.place.lng === place.lng)
       )
     );
   };


### PR DESCRIPTION

プレビュー表示を追加ボタンを押した後に毎回リセットされるように使用を変更
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/57d2baa8-8ad1-4eb3-9d0c-2f19b2d4636c" />

保存済みの場所を選択したときは保存済みではなく選択中のピンが立つように変更
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/09a6ea83-3bbf-4816-82d7-0e6caa671010" />

保存した写真が表示されないバグを修正